### PR TITLE
chore: fix ci and add cd.yaml

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,17 @@
+name: CD
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  cd:
+    uses: halo-sigs/reusable-workflows/.github/workflows/plugin-cd.yaml@v1
+    permissions:
+      contents: write
+    with:
+      skip-appstore-release: true
+      node-version: "20"
+      pnpm-version: "9"
+      ui-path: "ui"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   ci:


### PR DESCRIPTION
Fix the issue where ci could not run, and add cd configuration to automatically build artifacts after creating a release.