### PR TITLE
Add app-id to configuration and plugin annotations

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,3 +17,4 @@ jobs:
       pnpm-version: "10"
       java-version: "21"
       ui-path: "ui"
+      app-id: "app-fVJSY"

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -2,6 +2,8 @@ apiVersion: plugin.halo.run/v1alpha1
 kind: Plugin
 metadata:
   name: plugin-webp-se-cloud
+  annotations:
+    "store.halo.run/app-id": "app-fVJSY"
 spec:
   enabled: true
   requires: ">=2.22.10"


### PR DESCRIPTION
This PR adds app-id to configuration and plugin annotations to fix CD issue.

```release-note
None
```
