### PR TITLE
Fix the problem of not being able run in Halo 2.23

### DIFF
--- a/src/main/java/se/webp/plugin/halo/ImageTagProcessor.java
+++ b/src/main/java/se/webp/plugin/halo/ImageTagProcessor.java
@@ -74,7 +74,7 @@ public class ImageTagProcessor implements ElementTagPostProcessor {
             .filter(proxy -> urlMatches(externalUrl, proxy.getOriginUrl()))
             .next()
             .map(proxy -> {
-                var srcBuilder = UriComponentsBuilder.fromHttpUrl(proxy.getProxyUrl().toString())
+                var srcBuilder = UriComponentsBuilder.fromUriString(proxy.getProxyUrl().toString())
                     .path(srcValue.get().getPath())
                     .query(srcValue.get().getQuery())
                     .fragment(srcValue.get().getFragment());


### PR DESCRIPTION
This PR repalces deprecated method for URI building in ImageTagProcessor, so that it can run in Halo 2.23 properly.

